### PR TITLE
Fix the wrong PodSpec for nodemanager.yaml

### DIFF
--- a/hack/yaml/nodemanager.yaml
+++ b/hack/yaml/nodemanager.yaml
@@ -29,7 +29,7 @@ spec:
                 - node-manager
             topologyKey: kubernetes.io/hostname
       containers:
-        env:
+      - env:
         - name: GINIT_PORT
           value: xxx
         - name: USER


### PR DESCRIPTION
As we know the PodSpec's containers field is array type, but typo in nodemanager.yaml