### PR TITLE
chaning the copyright for the old has been de-registered

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Tencent is pleased to support the open source community by making Caelus available.
 
-Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved. The below software in this distribution may have been modified by THL A29 Limited (“Tencent Modifications”). All Tencent Modifications are Copyright (C) 2021 THL A29 Limited.
+Copyright (C) 2021 Tencent.  All rights reserved. The below software in this distribution may have been modified by Tencent (“Tencent Modifications”). All Tencent Modifications are Copyright (C) 2021 Tencent.
 
 Caelus is licensed under the Apache License Version 2.0 except for the third-party components listed below.
 
@@ -69,7 +69,7 @@ Other dependencies and licenses:
 
 
 Open Source Software Licensed under the Apache License Version 2.0:
-The below software in this distribution may have been modified by THL A29 Limited ("Tencent Modifications"). All Tencent Modifications are Copyright (C) 2021 THL A29 Limited.
+The below software in this distribution may have been modified by Tencent ("Tencent Modifications"). All Tencent Modifications are Copyright (C) 2021 Tencent.
 --------------------------------------------------------------------
 1. cadvisor
 Copyright 2014 The cAdvisor Authors
@@ -276,7 +276,7 @@ Use of this source code is governed by a BSD-style license.
 
 
 Open Source Software Licensed under the Apache License Version 2.0 and Other Licenses of the Third-Party Components therein:
-The below software in this distribution may have been modified by THL A29 Limited (“Tencent Modifications”). All Tencent Modifications are Copyright (C) 2021 THL A29 Limited.
+The below software in this distribution may have been modified by Tencent (“Tencent Modifications”). All Tencent Modifications are Copyright (C) 2021 Tencent.
 --------------------------------------------------------------------
 1. k8s.io/kubernetes
 Copyright 2015 The Kubernetes Authors.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ For more information about contributing issues or pull requests, see our [Contri
 
 ## License
 Caelus is under the Apache License 2.0. See the [License](LICENSE) file for details.
+
+The copyright notice pertaining to the Tencent code in this repo was previously in the name of “Tencent.”  That entity has now been de-registered.  You should treat all previously distributed copies of the code as if the copyright notice was in the name of “Tencent.”
+

--- a/cmd/caelus/app/api.go
+++ b/cmd/caelus/app/api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/caelus/app/server.go
+++ b/cmd/caelus/app/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/caelus/caelus.go
+++ b/cmd/caelus/caelus.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/caelus/context/context.go
+++ b/cmd/caelus/context/context.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/nm-operator/app/api.go
+++ b/cmd/nm-operator/app/api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/nm-operator/app/server.go
+++ b/cmd/nm-operator/app/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/nm-operator/nm_operator.go
+++ b/cmd/nm-operator/nm_operator.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/cmd/plugin-server/app/server.go
+++ b/contrib/lighthouse-plugin/cmd/plugin-server/app/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/cmd/plugin-server/plugin-server.go
+++ b/contrib/lighthouse-plugin/cmd/plugin-server/plugin-server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/common.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/offline/offline.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/offline/offline.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/offline/util.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/offline/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/pid-limit/pid_limit.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/pid-limit/pid_limit.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/prehook_create_plugin.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/prehook_create_plugin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/prehook_update_plugin.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/prehook_update_plugin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/storage-opts/storage_opts.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/storage-opts/storage_opts.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/docker/uts-mode/uts_mode.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/docker/uts-mode/uts_mode.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/meta.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/meta.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/plugin.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/plugin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/plugin/util/util.go
+++ b/contrib/lighthouse-plugin/pkg/plugin/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/server/register_plugin.go
+++ b/contrib/lighthouse-plugin/pkg/server/register_plugin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse-plugin/pkg/server/server.go
+++ b/contrib/lighthouse-plugin/pkg/server/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/cmd/lighthouse/app/server.go
+++ b/contrib/lighthouse/cmd/lighthouse/app/server.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/cmd/lighthouse/lighthouse.go
+++ b/contrib/lighthouse/cmd/lighthouse/lighthouse.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/register.go
+++ b/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/register.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/defaults.go
+++ b/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/defaults.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/doc.go
+++ b/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/register.go
+++ b/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/types.go
+++ b/contrib/lighthouse/pkg/apis/componentconfig.lighthouse.io/v1alpha1/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/hook_connector.go
+++ b/contrib/lighthouse/pkg/hook/hook_connector.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/hook_connector_test.go
+++ b/contrib/lighthouse/pkg/hook/hook_connector_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/hook_manager.go
+++ b/contrib/lighthouse/pkg/hook/hook_manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/hook_manager_test.go
+++ b/contrib/lighthouse/pkg/hook/hook_manager_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/proxy.go
+++ b/contrib/lighthouse/pkg/hook/proxy.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/types.go
+++ b/contrib/lighthouse/pkg/hook/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/hook/util.go
+++ b/contrib/lighthouse/pkg/hook/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/scheme/register.go
+++ b/contrib/lighthouse/pkg/scheme/register.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/test/test_util.go
+++ b/contrib/lighthouse/pkg/test/test_util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrib/lighthouse/pkg/util/util.go
+++ b/contrib/lighthouse/pkg/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/cadvisor/cadvisor.go
+++ b/pkg/cadvisor/cadvisor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/alarm/alarm.go
+++ b/pkg/caelus/alarm/alarm.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/alarm/alarm_test.go
+++ b/pkg/caelus/alarm/alarm_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/checkpoint/checkpoint.go
+++ b/pkg/caelus/checkpoint/checkpoint.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/checkpoint/checkpoint_test.go
+++ b/pkg/caelus/checkpoint/checkpoint_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/cpi/manager.go
+++ b/pkg/caelus/cpi/manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/cpi/time_series.go
+++ b/pkg/caelus/cpi/time_series.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/detector.go
+++ b/pkg/caelus/detection/detector.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/ewma.go
+++ b/pkg/caelus/detection/ewma.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/ewma_test.go
+++ b/pkg/caelus/detection/ewma_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/expression.go
+++ b/pkg/caelus/detection/expression.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/mock/mock.go
+++ b/pkg/caelus/detection/mock/mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/ring/ring.go
+++ b/pkg/caelus/detection/ring/ring.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/ring/ring_test.go
+++ b/pkg/caelus/detection/ring/ring_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/types.go
+++ b/pkg/caelus/detection/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/detection/union.go
+++ b/pkg/caelus/detection/union.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/diskquota.go
+++ b/pkg/caelus/diskquota/diskquota.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/diskquota_test.go
+++ b/pkg/caelus/diskquota/diskquota_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/interface.go
+++ b/pkg/caelus/diskquota/interface.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/manager/manager.go
+++ b/pkg/caelus/diskquota/manager/manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/manager/manager_fake.go
+++ b/pkg/caelus/diskquota/manager/manager_fake.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/manager/projectquota/projectfile_test.go
+++ b/pkg/caelus/diskquota/manager/projectquota/projectfile_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/manager/projectquota/projectquota_test.go
+++ b/pkg/caelus/diskquota/manager/projectquota/projectquota_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/emptydir.go
+++ b/pkg/caelus/diskquota/volumes/emptydir.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/emptydir_test.go
+++ b/pkg/caelus/diskquota/volumes/emptydir_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/hostpath.go
+++ b/pkg/caelus/diskquota/volumes/hostpath.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/hostpath_test.go
+++ b/pkg/caelus/diskquota/volumes/hostpath_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/rootfs.go
+++ b/pkg/caelus/diskquota/volumes/rootfs.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/rootfs_test.go
+++ b/pkg/caelus/diskquota/volumes/rootfs_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/volume.go
+++ b/pkg/caelus/diskquota/volumes/volume.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/diskquota/volumes/volume_fake.go
+++ b/pkg/caelus/diskquota/volumes/volume_fake.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action.go
+++ b/pkg/caelus/healthcheck/action/action.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_adjust.go
+++ b/pkg/caelus/healthcheck/action/action_adjust.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_adjust_test.go
+++ b/pkg/caelus/healthcheck/action/action_adjust_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_evict.go
+++ b/pkg/caelus/healthcheck/action/action_evict.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_log.go
+++ b/pkg/caelus/healthcheck/action/action_log.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_schedule.go
+++ b/pkg/caelus/healthcheck/action/action_schedule.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_schedule_test.go
+++ b/pkg/caelus/healthcheck/action/action_schedule_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/action/action_test.go
+++ b/pkg/caelus/healthcheck/action/action_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/cgroupnotify/notify.go
+++ b/pkg/caelus/healthcheck/cgroupnotify/notify.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/cgroupnotify/notify_memory.go
+++ b/pkg/caelus/healthcheck/cgroupnotify/notify_memory.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/conflict/conflict.go
+++ b/pkg/caelus/healthcheck/conflict/conflict.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/conflict/conflict_test.go
+++ b/pkg/caelus/healthcheck/conflict/conflict_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/conflict/mock/mock.go
+++ b/pkg/caelus/healthcheck/conflict/mock/mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/dispatcher/dispatcher.go
+++ b/pkg/caelus/healthcheck/dispatcher/dispatcher.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/dispatcher/dispatcher_test.go
+++ b/pkg/caelus/healthcheck/dispatcher/dispatcher_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/health_check.go
+++ b/pkg/caelus/healthcheck/health_check.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/health_check_test.go
+++ b/pkg/caelus/healthcheck/health_check_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/common.go
+++ b/pkg/caelus/healthcheck/rulecheck/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/common_test.go
+++ b/pkg/caelus/healthcheck/rulecheck/common_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/correlation/correlation.go
+++ b/pkg/caelus/healthcheck/rulecheck/correlation/correlation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/correlation/doc.go
+++ b/pkg/caelus/healthcheck/rulecheck/correlation/doc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/correlation/types.go
+++ b/pkg/caelus/healthcheck/rulecheck/correlation/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/rule_check.go
+++ b/pkg/caelus/healthcheck/rulecheck/rule_check.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/rule_check_app.go
+++ b/pkg/caelus/healthcheck/rulecheck/rule_check_app.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/rule_check_container.go
+++ b/pkg/caelus/healthcheck/rulecheck/rule_check_container.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/healthcheck/rulecheck/rule_check_node.go
+++ b/pkg/caelus/healthcheck/rulecheck/rule_check_node.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/common_metrics.go
+++ b/pkg/caelus/metrics/common_metrics.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/outer/serverrequest/serverrequest.go
+++ b/pkg/caelus/metrics/outer/serverrequest/serverrequest.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/outer/textfile/textfile_metrics.go
+++ b/pkg/caelus/metrics/outer/textfile/textfile_metrics.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/outer/utils.go
+++ b/pkg/caelus/metrics/outer/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/prometheus_config.go
+++ b/pkg/caelus/metrics/prometheus_config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/metrics/prometheus_metrics.go
+++ b/pkg/caelus/metrics/prometheus_metrics.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/mock/mock_pod_informer.go
+++ b/pkg/caelus/mock/mock_pod_informer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/mock/util.go
+++ b/pkg/caelus/mock/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/online/online.go
+++ b/pkg/caelus/online/online.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/online/online_test.go
+++ b/pkg/caelus/online/online_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/interface.go
+++ b/pkg/caelus/predict/interface.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/logic.go
+++ b/pkg/caelus/predict/logic.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/predict.go
+++ b/pkg/caelus/predict/predict.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/predict_local.go
+++ b/pkg/caelus/predict/predict_local.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/predict_local_test.go
+++ b/pkg/caelus/predict/predict_local_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/predict/predict_vpa.go
+++ b/pkg/caelus/predict/predict_vpa.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_cpu.go
+++ b/pkg/caelus/qos/manager/manage_cpu.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_cpu_test.go
+++ b/pkg/caelus/qos/manager/manage_cpu_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_diskio.go
+++ b/pkg/caelus/qos/manager/manage_diskio.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_memory.go
+++ b/pkg/caelus/qos/manager/manage_memory.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_memory_test.go
+++ b/pkg/caelus/qos/manager/manage_memory_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manage_netio.go
+++ b/pkg/caelus/qos/manager/manage_netio.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/manager.go
+++ b/pkg/caelus/qos/manager/manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/netio/log.go
+++ b/pkg/caelus/qos/manager/netio/log.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/manager/netio/netio.go
+++ b/pkg/caelus/qos/manager/netio/netio.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/mock/mock.go
+++ b/pkg/caelus/qos/mock/mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/qos.go
+++ b/pkg/caelus/qos/qos.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/qos/qos_k8s.go
+++ b/pkg/caelus/qos/qos_k8s.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/interface.go
+++ b/pkg/caelus/resource/interface.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/interface_mock.go
+++ b/pkg/caelus/resource/interface_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/k8s/types.go
+++ b/pkg/caelus/resource/k8s/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/resource.go
+++ b/pkg/caelus/resource/resource.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/resource_checkpoint.go
+++ b/pkg/caelus/resource/resource_checkpoint.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/resource_k8s.go
+++ b/pkg/caelus/resource/resource_k8s.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/resource_test.go
+++ b/pkg/caelus/resource/resource_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/resource_yarn.go
+++ b/pkg/caelus/resource/resource_yarn.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/adapter.go
+++ b/pkg/caelus/resource/yarn/adapter.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/adapter_test.go
+++ b/pkg/caelus/resource/yarn/adapter_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/container_sort.go
+++ b/pkg/caelus/resource/yarn/container_sort.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/disks.go
+++ b/pkg/caelus/resource/yarn/disks.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/ginit.go
+++ b/pkg/caelus/resource/yarn/ginit.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/ginit_mock.go
+++ b/pkg/caelus/resource/yarn/ginit_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/metrics.go
+++ b/pkg/caelus/resource/yarn/metrics.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/port.go
+++ b/pkg/caelus/resource/yarn/port.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/resource/yarn/utils.go
+++ b/pkg/caelus/resource/yarn/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/cgroup/cgroup.go
+++ b/pkg/caelus/statestore/cgroup/cgroup.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/cgroup/cgroup_test.go
+++ b/pkg/caelus/statestore/cgroup/cgroup_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/cgroup/types.go
+++ b/pkg/caelus/statestore/cgroup/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/cgroup/utils.go
+++ b/pkg/caelus/statestore/cgroup/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/customize/app.go
+++ b/pkg/caelus/statestore/common/customize/app.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/customize/types.go
+++ b/pkg/caelus/statestore/common/customize/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/node/node.go
+++ b/pkg/caelus/statestore/common/node/node.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/node/type.go
+++ b/pkg/caelus/statestore/common/node/type.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/perf/perf.go
+++ b/pkg/caelus/statestore/common/perf/perf.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/perf/pmu/pmu.go
+++ b/pkg/caelus/statestore/common/perf/pmu/pmu.go
@@ -2,7 +2,7 @@
 // +build linux
 
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/prometheus/prometheus.go
+++ b/pkg/caelus/statestore/common/prometheus/prometheus.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/rdt/rdt.go
+++ b/pkg/caelus/statestore/common/rdt/rdt.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/rdt/rdt/rdt.go
+++ b/pkg/caelus/statestore/common/rdt/rdt/rdt.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/common/state_common.go
+++ b/pkg/caelus/statestore/common/state_common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/mock/stats_cgroup_mock.go
+++ b/pkg/caelus/statestore/mock/stats_cgroup_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/mock/stats_common_mock.go
+++ b/pkg/caelus/statestore/mock/stats_common_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/mock/stats_mock.go
+++ b/pkg/caelus/statestore/mock/stats_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/statestore/state_store.go
+++ b/pkg/caelus/statestore/state_store.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/types/diskquota.go
+++ b/pkg/caelus/types/diskquota.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/types/health_check.go
+++ b/pkg/caelus/types/health_check.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/types/predict.go
+++ b/pkg/caelus/types/predict.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/types/types.go
+++ b/pkg/caelus/types/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/appclass/appclass.go
+++ b/pkg/caelus/util/appclass/appclass.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/appclass/appclass_test.go
+++ b/pkg/caelus/util/appclass/appclass_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/blkio.go
+++ b/pkg/caelus/util/cgroup/blkio.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/blkio_test.go
+++ b/pkg/caelus/util/cgroup/blkio_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cgroup.go
+++ b/pkg/caelus/util/cgroup/cgroup.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cgroup_test.go
+++ b/pkg/caelus/util/cgroup/cgroup_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpu.go
+++ b/pkg/caelus/util/cgroup/cpu.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpu_test.go
+++ b/pkg/caelus/util/cgroup/cpu_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpubt.go
+++ b/pkg/caelus/util/cgroup/cpubt.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpubt_test.go
+++ b/pkg/caelus/util/cgroup/cpubt_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpuset.go
+++ b/pkg/caelus/util/cgroup/cpuset.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/cpuset_test.go
+++ b/pkg/caelus/util/cgroup/cpuset_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/memory.go
+++ b/pkg/caelus/util/cgroup/memory.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/perf_event.go
+++ b/pkg/caelus/util/cgroup/perf_event.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/topology.go
+++ b/pkg/caelus/util/cgroup/topology.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/cgroup/topology_test.go
+++ b/pkg/caelus/util/cgroup/topology_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/errors.go
+++ b/pkg/caelus/util/errors.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/machine/machine.go
+++ b/pkg/caelus/util/machine/machine.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/machine/machine_test.go
+++ b/pkg/caelus/util/machine/machine_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/machine/speed.go
+++ b/pkg/caelus/util/machine/speed.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/ports/ports.go
+++ b/pkg/caelus/util/ports/ports.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/runtime/docker/docker.go
+++ b/pkg/caelus/util/runtime/docker/docker.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/runtime/docker/docker_fake.go
+++ b/pkg/caelus/util/runtime/docker/docker_fake.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/runtime/runtime.go
+++ b/pkg/caelus/util/runtime/runtime.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/sets/pods.go
+++ b/pkg/caelus/util/sets/pods.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/caelus/util/util.go
+++ b/pkg/caelus/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/hadoop/hadoop_conf.go
+++ b/pkg/nm-operator/hadoop/hadoop_conf.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/hadoop/hadoop_conf_test.go
+++ b/pkg/nm-operator/hadoop/hadoop_conf_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/nmoperator/nm_operator.go
+++ b/pkg/nm-operator/nmoperator/nm_operator.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/types/types.go
+++ b/pkg/nm-operator/types/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/util/util.go
+++ b/pkg/nm-operator/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/nm-operator/util/util_test.go
+++ b/pkg/nm-operator/util/util_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/types/type.go
+++ b/pkg/types/type.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/types/types_yarn.go
+++ b/pkg/types/types_yarn.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/util/times/times.go
+++ b/pkg/util/times/times.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/util/times/times_test.go
+++ b/pkg/util/times/times_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 THL A29 Limited, a Tencent company.
+ * Copyright (c) 2021 Tencent.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The copyright notice pertaining to the Tencent code in this repo was previously in the name of “THL A29 Limited.”  That entity has now been de-registered and should be changed to the name of “Tencent.”